### PR TITLE
Add fix for web entity detection

### DIFF
--- a/summarization/web_entity_detection.py
+++ b/summarization/web_entity_detection.py
@@ -155,7 +155,7 @@ class ImageDescriptionRetriever:
 
     def _get_best_guess_label(self, image_response):
         ''' return the best guess label '''
-        if 'error' in image_response or "label" \
+        if "error" in image_response or "label" \
                 not in image_response["webDetection"]["bestGuessLabels"][0]:
             return ""
         return image_response["webDetection"]["bestGuessLabels"][0]["label"]
@@ -163,7 +163,7 @@ class ImageDescriptionRetriever:
     def _get_top_entities(self, image_response, number_of_entities):
         ''' return the top entity description'''
 
-        if 'error' in image_response:
+        if "error" in image_response:
             return [""]
 
         number_of_entities = min(number_of_entities, len(

--- a/summarization/web_entity_detection.py
+++ b/summarization/web_entity_detection.py
@@ -65,11 +65,11 @@ class ImageDescriptionRetriever:
 
     def _split_into_batches(self):
         self.image_url_batches = list()
-        list_len = len(self.image_urls)
+        num_image_urls = len(self.image_urls)
         i = 0
-        while i < list_len:
+        while i < num_image_urls:
             self.image_url_batches.append(
-                self.image_urls[i:min(i + self.BATCH_SIZE, list_len)]
+                self.image_urls[i:min(i + self.BATCH_SIZE, num_image_urls)]
             )
             i += self.BATCH_SIZE
 

--- a/summarization/web_entity_detection.py
+++ b/summarization/web_entity_detection.py
@@ -11,6 +11,7 @@ The script contains the following classes:
 '''
 
 import base64
+import concurrent.futures as cf
 import json
 import os
 
@@ -28,6 +29,8 @@ class ImageDescriptionRetriever:
 
     API_ENDPOINT \
         = "https://vision.googleapis.com/v1/images:annotate?key="
+
+    BATCH_SIZE = 5  # number of images per api request
 
     def __init__(self, max_entities=3):
         self.api_key \
@@ -47,9 +50,55 @@ class ImageDescriptionRetriever:
         list<str> : list containing best guess descriptions of the image
         '''
         self.image_urls = image_urls
+
+        # split into batches based on batch size
+        self._split_into_batches()
+
+        # make each request in a single thread
+        # this is done since request natively only
+        # allows one request per thread
+        self._make_concurrent_requests()
+
+        # we need to get the same order as
+        # that of the given image_urls
+        return self._get_ordered_and_combined_request_responses()
+
+    def _split_into_batches(self):
+        self.image_url_batches = list()
+        list_len = len(self.image_urls)
+        i = 0
+        while i < list_len:
+            self.image_url_batches.append(
+                self.image_urls[i:min(i + self.BATCH_SIZE, list_len)]
+            )
+            i += self.BATCH_SIZE
+
+    def _make_concurrent_requests(self):
+        self.all_responses_list = list()
+        executor = cf.ThreadPoolExecutor(max_workers=4)
+        future_list = [
+            executor.submit(
+                self._make_post_request,
+                self.image_url_batches[i],
+                i) for i in range(len(self.image_url_batches))]
+        for future in cf.as_completed(future_list):
+            self.all_responses_list.append(future.result())
+
+    def _get_ordered_and_combined_request_responses(self):
+        # sort based on request number
+        self.all_responses_list.sort()
+        image_descriptions = list()
+        for _, img_desc in self.all_responses_list:
+            image_descriptions.extend(img_desc)
+
+        return image_descriptions
+
+    def _make_post_request(self, image_urls, request_number):
+        # request number will be used to order
+        # all the requests finally
         image_requests \
             = [self._format_single_request(url) for
-                url in self.image_urls]
+                url in image_urls]
 
         json_data_for_post_request = json.dumps({
             "requests": image_requests
@@ -57,24 +106,24 @@ class ImageDescriptionRetriever:
         response = requests.post(self.api_url, data=json_data_for_post_request)
 
         if response.status_code != 200:
+            print(response.content)
             raise BadRequestError(response.status_code)
 
         response = json.loads(response.content)
         image_descriptions = []
-        for i in range(len(self.image_urls)):
+        for i in range(len(image_urls)):
             image_descriptions.append(
                 {
                     "label": self._get_best_guess_label(
-                            response["responses"][i]
-                            ),
+                        response["responses"][i]
+                    ),
                     "entities": self._get_top_entities(
-                                response["responses"][i],
-                                self.max_entities
-                                )
+                        response["responses"][i],
+                        self.max_entities
+                    )
                 }
             )
-
-        return image_descriptions
+        return request_number, image_descriptions
 
     def _format_single_request(self, url: str) -> dict:
         '''
@@ -106,10 +155,16 @@ class ImageDescriptionRetriever:
 
     def _get_best_guess_label(self, image_response):
         ''' return the best guess label '''
+        if 'error' in image_response or "label" \
+                not in image_response["webDetection"]["bestGuessLabels"][0]:
+            return ""
         return image_response["webDetection"]["bestGuessLabels"][0]["label"]
 
     def _get_top_entities(self, image_response, number_of_entities):
         ''' return the top entity description'''
+
+        if 'error' in image_response:
+            return [""]
 
         number_of_entities = min(number_of_entities, len(
             image_response["webDetection"]["webEntities"]))

--- a/tests/summarizer/test_image_description_retreiver.py
+++ b/tests/summarizer/test_image_description_retreiver.py
@@ -8,7 +8,7 @@ from summarization.web_entity_detection import ImageDescriptionRetriever
 
 
 def mocked_requests_post(*args, **kwargs):
-    json_data = json.loads(kwargs['data'])
+    json_data = json.loads(kwargs["data"])
     label = ""
     entity = ""
     status_code = 200
@@ -50,11 +50,11 @@ def mocked_requests_post(*args, **kwargs):
 
 
 @patch(
-    'summarization.web_entity_detection.requests.post',
+    "summarization.web_entity_detection.requests.post",
     side_effect=mocked_requests_post)
 def test_request_format(mocked_post):
     image_describer = ImageDescriptionRetriever(1)
-    formatted_request = image_describer._format_single_request('url')
+    formatted_request = image_describer._format_single_request("url")
 
     assert isinstance(formatted_request, dict)
 
@@ -63,7 +63,7 @@ def test_request_format(mocked_post):
     assert "source" in formatted_request["image"]
     assert isinstance(formatted_request["image"]["source"], dict)
     assert "imageUri" in formatted_request["image"]["source"]
-    assert formatted_request["image"]["source"]["imageUri"] == 'url'
+    assert formatted_request["image"]["source"]["imageUri"] == "url"
 
     assert "features" in formatted_request
     assert isinstance(formatted_request["features"], list)
@@ -86,29 +86,29 @@ def test_request_format(mocked_post):
 
 
 @ patch(
-    'summarization.web_entity_detection.requests.post',
+    "summarization.web_entity_detection.requests.post",
     side_effect=mocked_requests_post)
 def test_web_entity_detection(mocked_post):
     image_describer = ImageDescriptionRetriever(1)
 
     reponse_for_image_url_1 = image_describer.get_description_for_images(
         ["https://tinyurl.com/y7how2rj"])[0]
-    assert 'sundar pichai' in reponse_for_image_url_1['label']
-    assert 'sundar pichai Alphabet' in reponse_for_image_url_1['entities']
+    assert "sundar pichai" in reponse_for_image_url_1["label"]
+    assert "sundar pichai Alphabet" in reponse_for_image_url_1["entities"]
 
     reponse_for_image_url_2 = image_describer.get_description_for_images(
         ["https://tinyurl.com/y9bvoehm"])[0]
-    assert 'larry page' in reponse_for_image_url_2['label']
-    assert 'larry page google' in reponse_for_image_url_2['entities']
+    assert "larry page" in reponse_for_image_url_2["label"]
+    assert "larry page google" in reponse_for_image_url_2["entities"]
 
     reponse_for_image_url_3 = image_describer.get_description_for_images(
         ["https://tinyurl.com/y9t35t3z"])[0]
-    assert 'sergey brin' in reponse_for_image_url_3['label']
-    assert 'sergey brin google' in reponse_for_image_url_3['entities']
+    assert "sergey brin" in reponse_for_image_url_3["label"]
+    assert "sergey brin google" in reponse_for_image_url_3["entities"]
 
 
 @ patch(
-    'summarization.web_entity_detection.requests.post',
+    "summarization.web_entity_detection.requests.post",
     side_effect=mocked_requests_post)
 def test_bad_request(mocked_post):
     image_describer = ImageDescriptionRetriever(1)
@@ -177,3 +177,19 @@ def test_request_ordering():
     )
     assert image_describer._get_ordered_and_combined_request_responses() == \
         ["zero", "one", "two"]
+
+
+@ patch(
+    "summarization.web_entity_detection.requests.post",
+    side_effect=mocked_requests_post)
+def test_request_number(mocked_post):
+    image_describer = ImageDescriptionRetriever(1)
+
+    actual_request_number = 1
+
+    returned_request_number, _ = image_describer._make_post_request(
+        ["https://tinyurl.com/y9t35t3z"],
+        actual_request_number
+    )
+
+    assert actual_request_number == returned_request_number


### PR DESCRIPTION
* Make web_entity_detection perform concurrent API requests since images/request is limited to 5 images
* Return an empty string/empty list for now when the image url cannot be retrieved.