### PR TITLE
Creating a entry run_server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ variables:
 
 ### Flask Server
     
-`$ python api/server.py`
+`$ python run_server.py`
 
 The server will be hosted at http://127.0.0.1:5000/
 

--- a/run_server.py
+++ b/run_server.py
@@ -1,0 +1,3 @@
+from api.server import app
+
+app.run()


### PR DESCRIPTION
Running 'python api/server.py' messes up the packages (Unable to find module error, stampify).

Creating a run_server.py in the top level directory to run the server. (Also to get used to git workflow)